### PR TITLE
AtaqueDeCatapulta ahora ataca a unidades contiguas 

### DIFF
--- a/src/main/java/Algo3TP2/Modelos/Unidades/EstrategiasDeAtaque/AtaqueDeCatapulta.java
+++ b/src/main/java/Algo3TP2/Modelos/Unidades/EstrategiasDeAtaque/AtaqueDeCatapulta.java
@@ -1,5 +1,9 @@
 package Algo3TP2.Modelos.Unidades.EstrategiasDeAtaque;
 
+import Algo3TP2.Modelos.Casillero.Casillero;
+import Algo3TP2.Modelos.Casillero.ExcepcionesCasillero.CasilleroVacioExcepcion;
+import Algo3TP2.Modelos.Tablero.ExcepcionesTablero.CasilleroFueraDelLosLimitesDelTableroExcepcion;
+import Algo3TP2.Modelos.Tablero.Tablero;
 import Algo3TP2.Modelos.Unidades.EstrategiasDeAtaque.ExcepcionesAtaque.DistanciaDeAtaqueIncorrectaExcepcion;
 import Algo3TP2.Modelos.UnidadInvalidaException;
 import Algo3TP2.Modelos.Unidades.EstrategiasDeAtaque.ExcepcionesAtaque.UnidadAtacadaEsAliadaExcepcion;
@@ -21,5 +25,20 @@ public class AtaqueDeCatapulta extends DistanciaLarga {
         }
 
         unidadVictima.recibirDanio(Properties.danioCatapultaDistancia);
+
+        atacarUnidadesContiguas(unidadVictima.getCasillero());
+    }
+
+    private void atacarUnidadesContiguas(Casillero casilleroActual) throws UnidadInvalidaException{
+        try {
+            Casillero casilleroContiguo = Tablero.getTablero().
+                    getCasilleroEnPosicion(casilleroActual.getCoordenadaX()-1, casilleroActual.getCoordenadaY());
+            Unidad unidadContigua = casilleroContiguo.getUnidad();
+            unidadContigua.recibirDanio(Properties.danioCatapultaDistancia);
+            atacarUnidadesContiguas(casilleroContiguo);
+
+        } catch (CasilleroFueraDelLosLimitesDelTableroExcepcion | CasilleroVacioExcepcion ex){
+            // Freno la iteracion
+        }
     }
 }

--- a/src/test/java/Algo3TP2/EntidadesTests/CatapultaTest.java
+++ b/src/test/java/Algo3TP2/EntidadesTests/CatapultaTest.java
@@ -1,11 +1,18 @@
 package Algo3TP2.EntidadesTests;
 
 import Algo3TP2.Modelos.Casillero.Casillero;
+import Algo3TP2.Modelos.Casillero.ExcepcionesCasillero.CasilleroOcupadoExcepcion;
+import Algo3TP2.Modelos.Casillero.ExcepcionesCasillero.CasilleroVacioExcepcion;
+import Algo3TP2.Modelos.Tablero.ExcepcionesTablero.CasilleroFueraDelLosLimitesDelTableroExcepcion;
+import Algo3TP2.Modelos.Tablero.Tablero;
 import Algo3TP2.Modelos.Unidades.EstrategiasDeAtaque.ExcepcionesAtaque.DistanciaDeAtaqueIncorrectaExcepcion;
 import Algo3TP2.Modelos.Unidades.EstrategiasDeAtaque.ExcepcionesAtaque.UnidadAtacadaEsAliadaExcepcion;
 import Algo3TP2.Modelos.*;
 import Algo3TP2.Modelos.Unidades.Catapulta;
+import Algo3TP2.Modelos.Unidades.Jinete;
+import Algo3TP2.Modelos.Unidades.Soldado;
 import Algo3TP2.Modelos.Unidades.Unidad;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -196,5 +203,49 @@ public class CatapultaTest {
 
         // Assert
         assertEquals(30, catapultaAtacada.getVida());
+    }
+
+    @Test
+    public void CatapultaAtacaAUnidadGeneraDanioATodasLasUnidadesContiguas()
+            throws DistanciaDeAtaqueIncorrectaExcepcion, UnidadAtacadaEsAliadaExcepcion, UnidadInvalidaException,
+            CasilleroFueraDelLosLimitesDelTableroExcepcion, CasilleroOcupadoExcepcion {
+        // Arrange
+        Jugador jugador1 = new Jugador(); Bando bando1 = new Bando(jugador1);
+        Jugador jugador2 = new Jugador(); Bando bando2 = new Bando(jugador2);
+        Tablero tablero = Tablero.getTablero();
+        tablero.inicializarTablero(20,20, jugador1, jugador2);
+
+        Casillero casilleroAtacante = tablero.getCasilleroEnPosicion(1,1);
+        Catapulta catapultaAtacante = new Catapulta(bando1);
+        catapultaAtacante.colocarEnCasillero(casilleroAtacante);
+
+        Casillero casilleroAtacado1 = tablero.getCasilleroEnPosicion(7,7);
+        Soldado soldadoAtacado1 = new Soldado(bando1);
+        soldadoAtacado1.colocarEnCasillero(casilleroAtacado1);
+        casilleroAtacado1.setUnidad(soldadoAtacado1);
+
+        Casillero casilleroAtacado2 = tablero.getCasilleroEnPosicion(6,7);
+        Soldado soldadoAtacado2 = new Soldado(bando2);
+        soldadoAtacado2.colocarEnCasillero(casilleroAtacado2);
+        casilleroAtacado2.setUnidad(soldadoAtacado2);
+
+        Casillero casilleroAtacado3 = tablero.getCasilleroEnPosicion(5,7);
+        Jinete jineteAtacado3 = new Jinete(bando2);
+        jineteAtacado3.colocarEnCasillero(casilleroAtacado3);
+        casilleroAtacado3.setUnidad(jineteAtacado3);
+
+        Casillero casilleroNoAtacado4 = tablero.getCasilleroEnPosicion(3,7);
+        Jinete jineteNoAtacado4 = new Jinete(bando1);
+        jineteNoAtacado4.colocarEnCasillero(casilleroNoAtacado4);
+        casilleroNoAtacado4.setUnidad(jineteNoAtacado4);
+
+        // Act
+        catapultaAtacante.atacar(soldadoAtacado1);
+
+        // Assert
+        assertEquals(80, soldadoAtacado1.getVida());
+        assertEquals(80, soldadoAtacado2.getVida());
+        assertEquals(80, jineteAtacado3.getVida());
+        assertEquals(100, jineteNoAtacado4.getVida());
     }
 }


### PR DESCRIPTION
Modifico la estrategia de ataque AtaqueDeCatapulta para que realice danio a todas las unidades contiguas. Es posible que el codigo pueda ser refactorizado para que se vea un poco mas agradable